### PR TITLE
Quests list reloading

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
   ],
   rules: {
     'prettier/prettier': 'off',
+    'react-hooks/exhaustive-deps': 'off',
     'eslint-comments/no-unlimited-disable': 'off',
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': 'off',

--- a/src/components/questBlocks/QuestEnding.tsx
+++ b/src/components/questBlocks/QuestEnding.tsx
@@ -69,7 +69,7 @@ export default function QuestEnding(props: QuestEndingProps): React.ReactElement
               onError: err => console.error(err),
             }
           );
-          navigation.navigate('List');
+          navigation.navigate('List', { needRefresh: true });
         }}
       />
     </Body>

--- a/src/navigation/questsStack.tsx
+++ b/src/navigation/questsStack.tsx
@@ -7,7 +7,7 @@ import QuestInfoScreen from '../screens/QuestInfo';
  * Type with params of screens and their props in QuestsStackScreen
  */
 export type QuestsStackParamList = {
-  List: undefined;
+  List: { needRefresh: boolean };
   Description: {id: string; title: string; description: string | null, locked: boolean};
 };
 

--- a/src/screens/QuestsList.tsx
+++ b/src/screens/QuestsList.tsx
@@ -74,11 +74,11 @@ function QuestsListScreen(props: QuestsListQueryResponse & {retry: (() => void) 
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    setIsLoading(props.needRefresh);
     if (props.retry) {
+      setIsLoading(props.needRefresh);
       props.retry();
+      setIsLoading(false);
     }
-    setIsLoading(false);
   }, [ props.needRefresh ]);
 
   /**

--- a/src/screens/QuestsList.tsx
+++ b/src/screens/QuestsList.tsx
@@ -75,7 +75,7 @@ function QuestsListScreen(props: QuestsListQueryResponse & {retry: (() => void) 
 
   useEffect(() => {
     if (props.retry && props.needRefresh) {
-      setIsLoading(props.needRefresh);
+      setIsLoading(true);
       props.retry();
       setIsLoading(false);
     }

--- a/src/screens/QuestsList.tsx
+++ b/src/screens/QuestsList.tsx
@@ -74,7 +74,7 @@ function QuestsListScreen(props: QuestsListQueryResponse & {retry: (() => void) 
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    if (props.retry) {
+    if (props.retry && props.needRefresh) {
       setIsLoading(props.needRefresh);
       props.retry();
       setIsLoading(false);

--- a/src/screens/QuestsList.tsx
+++ b/src/screens/QuestsList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FlatList, RefreshControl, ScrollView } from 'react-native';
 import { Spinner } from 'native-base';
 import { graphql, QueryRenderer } from 'react-relay';
@@ -7,7 +7,7 @@ import {
   QuestsListQuery,
   QuestsListQueryResponse
 } from './__generated__/QuestsListQuery.graphql';
-import { StackNavigationProp } from '@react-navigation/stack';
+import { StackNavigationProp, StackScreenProps } from '@react-navigation/stack';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import { QuestsStackParamList } from '../navigation/questsStack';
@@ -21,6 +21,11 @@ import QuestsListItem from '../components/QuestsListItem';
  * Type with props of screen 'List' in QuestsStackScreen
  */
 type ListScreenNavigationProp = StackNavigationProp<QuestsStackParamList, 'List'>;
+
+/**
+ * Type with props of screen 'List' in QuestsStackScreen
+ */
+type Props = StackScreenProps<QuestsStackParamList, 'List'>;
 
 const Body = styled.View`
   background-color: ${Colors.Background};
@@ -63,10 +68,18 @@ const ErrorText = styled.Text`
  *
  * @param props - data with query results
  */
-function QuestsListScreen(props: QuestsListQueryResponse & {retry: (() => void) | null}): React.ReactElement {
+function QuestsListScreen(props: QuestsListQueryResponse & {retry: (() => void) | null, needRefresh: boolean}): React.ReactElement {
   const navigation = useNavigation<ListScreenNavigationProp>();
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(props.needRefresh);
+    if (props.retry) {
+      props.retry();
+    }
+    setIsLoading(false);
+  }, [ props.needRefresh ]);
 
   /**
    * The order in which the quests should be shown
@@ -185,8 +198,10 @@ const query = graphql`
 
 /**
  * Functional component of the query result
+ *
+ * @param route - route props of screen 'List'
  */
-export default function Quests(): React.ReactElement {
+export default function Quests({ route }: Props): React.ReactElement {
   return (
     <QueryRenderer<QuestsListQuery>
       environment={env}
@@ -199,7 +214,7 @@ export default function Quests(): React.ReactElement {
           );
         }
         if (props) {
-          return <QuestsListScreen {...props} retry={retry} />;
+          return <QuestsListScreen {...props} retry={retry} needRefresh={route.params?.needRefresh || false}/>;
         }
 
         return (


### PR DESCRIPTION
После прохождения квеста, у пользователя может вырасти уровень, однако, пока он не обновит список вручную, квесты, ставшие доступными на его уровне имеют статус заблокированных
Например, я получил 8 уровень, а у меня в списке болтается заблокированный квест с пометкой "Достигните уровня 8"
Теперь список обновляется после каждого завершения квеста и ставшие доступными квесты автоматически меняют свой статус